### PR TITLE
Implement structured error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
         <div class="app-footer">
             <p><span data-i18n="app.crafted_by">Crafted with 🦀 by</span> <a href="https://github.com/ZenonEl" target="_blank">ZenonEl</a></p>
-            <p class="version-info" data-i18n="app.version">CrabVoice v0.3.3 Public Beta</p>
+            <p class="version-info" data-i18n="app.version">CrabVoice v0.5.0 Public Beta</p>
             <p style="font-size:10px;color:#555;margin-top:4px;">(Using <a href="https://sponsor.ajay.app/" style="color:#777;">SponsorBlock</a> data under CC BY-NC-SA 4.0)</p>
 
             <!-- Socials -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CrabVoice",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "CrabVoice"
-version = "0.3.3"
+version = "0.5.0"
 description = "Cross-platform real-time voice-over translation app for video platforms. Features native audio sync, vot.js integration, and mobile support"
 authors = ["Zenonel"]
 edition = "2021"

--- a/src-tauri/injector.js
+++ b/src-tauri/injector.js
@@ -3585,7 +3585,7 @@
   var en_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "Real-time Native Video Translation",
-    "app.version": "CrabVoice v0.3.3 Public Beta",
+    "app.version": "CrabVoice v0.5.0 Public Beta",
     "app.crafted_by": "Crafted with \u{1F980} by",
     "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",
     "url.open": "Open Video",
@@ -3645,7 +3645,7 @@
   var ru_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "\u041D\u0430\u0442\u0438\u0432\u043D\u044B\u0439 \u0433\u043E\u043B\u043E\u0441\u043E\u0432\u043E\u0439 \u043F\u0435\u0440\u0435\u0432\u043E\u0434 \u0432\u0438\u0434\u0435\u043E",
-    "app.version": "CrabVoice v0.3.3 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
+    "app.version": "CrabVoice v0.5.0 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
     "app.crafted_by": "\u0421\u0434\u0435\u043B\u0430\u043D\u043E \u0441 \u{1F980} \u043E\u0442",
     "url.placeholder": "\u0412\u0441\u0442\u0430\u0432\u044C\u0442\u0435 \u0441\u0441\u044B\u043B\u043A\u0443 \u043D\u0430 \u0432\u0438\u0434\u0435\u043E (YouTube, VK, Vimeo)...",
     "url.open": "\u041E\u0442\u043A\u0440\u044B\u0442\u044C \u0432\u0438\u0434\u0435\u043E",
@@ -3929,6 +3929,7 @@
                         <button class="cv-sb-btn ${this.tier === "free" ? "disabled" : ""} ${this.sponsorBlockEnabled && this.tier !== "free" ? "active" : ""}" id="cv-sb-toggle">
                             ${Icons.sponsorblock || "\u23ED"} ${this.tier === "free" ? t("panel.sb_na") : this.sponsorBlockEnabled ? t("panel.sb_on") : t("panel.sb_off")}
                         </button>
+                        ${this.tier !== "free" ? '<div style="font-size:9px;color:#666;text-align:center;margin-top:-8px;margin-bottom:8px;">(Using <a href="https://sponsor.ajay.app/" target="_blank" style="color:#888;">sponsor.ajay.app</a>)</div>' : ""}
 
                         <div class="cv-btn-group">
                             <button class="cv-btn" id="cv-toggle-play">${t("panel.pause")}</button>

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -1,3 +1,4 @@
+use crate::error::AppError;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -66,5 +67,5 @@ pub trait TranslationProvider: Send + Sync {
         video_url: &str,
         duration: f64,
         settings: &AppSettings,
-    ) -> Result<TranslationResult, String>;
+    ) -> Result<TranslationResult, AppError>;
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,71 @@
+use std::fmt;
+
+/// Structured error type for the entire app.
+/// Converts to user-friendly strings at IPC boundary.
+#[derive(Debug)]
+pub enum AppError {
+    /// Network connectivity issues (proxy, DNS, timeout)
+    Network(String),
+    /// External API errors (Yandex, SponsorBlock)
+    Api(String),
+    /// Serialization/deserialization failures (protobuf, JSON)
+    Parse(String),
+    /// Configuration/settings issues
+    Config(String),
+    /// File system operations
+    Io(String),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::Network(msg) => write!(f, "Network error: {}", msg),
+            AppError::Api(msg) => write!(f, "API error: {}", msg),
+            AppError::Parse(msg) => write!(f, "Parse error: {}", msg),
+            AppError::Config(msg) => write!(f, "Config error: {}", msg),
+            AppError::Io(msg) => write!(f, "IO error: {}", msg),
+        }
+    }
+}
+
+impl From<AppError> for String {
+    fn from(e: AppError) -> String {
+        e.to_string()
+    }
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        AppError::Io(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::Parse(e.to_string())
+    }
+}
+
+impl From<reqwest::Error> for AppError {
+    fn from(e: reqwest::Error) -> Self {
+        if e.is_connect() || e.is_timeout() {
+            AppError::Network(e.to_string())
+        } else if e.is_decode() {
+            AppError::Parse(e.to_string())
+        } else {
+            AppError::Network(e.to_string())
+        }
+    }
+}
+
+impl From<prost::EncodeError> for AppError {
+    fn from(e: prost::EncodeError) -> Self {
+        AppError::Parse(format!("Protobuf encode: {}", e))
+    }
+}
+
+impl From<prost::DecodeError> for AppError {
+    fn from(e: prost::DecodeError) -> Self {
+        AppError::Parse(format!("Protobuf decode: {}", e))
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod domain;
+mod error;
 mod premium;
 mod settings;
 mod yandex_api;
@@ -7,7 +8,7 @@ use domain::{AppSettings, TranslationProvider, TranslationResult};
 use settings::SettingsManager;
 use yandex_api::YandexClient;
 
-use log::{error, info};
+use log::{error, info, warn};
 use std::fs;
 use std::sync::Arc;
 use tauri::{Manager, State};
@@ -20,7 +21,6 @@ struct AppState {
     settings_manager: SettingsManager,
 }
 
-// Команда-мост для инжектора (так как на внешних сайтах JS API плагина недоступен)
 #[tauri::command]
 fn log_message(source: String, msg: String) {
     if source == "error" || source.contains("Error") {
@@ -32,13 +32,16 @@ fn log_message(source: String, msg: String) {
 
 #[tauri::command]
 async fn get_logs(app: tauri::AppHandle) -> Result<String, String> {
-    let log_dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
-    
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| format!("Config error: {}", e))?;
+
     let mut all_logs = String::new();
     if let Ok(entries) = fs::read_dir(&log_dir) {
         let mut files: Vec<_> = entries.filter_map(|e| e.ok()).collect();
         files.sort_by_key(|a| a.metadata().and_then(|m| m.modified()).ok());
-        
+
         for entry in files {
             if entry.path().extension().map_or(false, |ext| ext == "log") {
                 if let Ok(content) = fs::read_to_string(entry.path()) {
@@ -48,7 +51,7 @@ async fn get_logs(app: tauri::AppHandle) -> Result<String, String> {
             }
         }
     }
-    
+
     if all_logs.is_empty() {
         Ok("Logs are empty or not found.".to_string())
     } else {
@@ -56,20 +59,22 @@ async fn get_logs(app: tauri::AppHandle) -> Result<String, String> {
     }
 }
 
-// Новая команда: надежный экспорт логов
 #[tauri::command]
 async fn export_logs(app: tauri::AppHandle) -> Result<String, String> {
     let logs = get_logs(app.clone()).await?;
-    
-    // Пытаемся сохранить в Загрузки, если не выйдет - в Документы
+
     let mut path = match app.path().download_dir() {
         Ok(p) => p,
-        Err(_) => app.path().document_dir().map_err(|e| e.to_string())?,
+        Err(_) => app
+            .path()
+            .document_dir()
+            .map_err(|e| format!("IO error: cannot find export directory: {}", e))?,
     };
-    
+
     path.push("crabvoice.log");
-    fs::write(&path, &logs).map_err(|e| format!("Failed to write file: {}", e))?;
-    
+    fs::write(&path, &logs).map_err(|e| format!("IO error: failed to write log file: {}", e))?;
+    info!("Logs exported to {}", path.display());
+
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -79,39 +84,57 @@ fn get_app_tier() -> &'static str {
     premium::get_tier()
 }
 
-// Команда получения сегментов с рекламой
 #[tauri::command]
-async fn get_skip_segments(video_id: String) -> Result<Vec<premium::SponsorSegment>, String> {
-    premium::fetch_sponsor_segments(&video_id).await
+async fn get_skip_segments(
+    video_id: String,
+) -> Result<Vec<premium::SponsorSegment>, String> {
+    premium::fetch_sponsor_segments(&video_id)
+        .await
+        .map_err(|e| {
+            warn!("SponsorBlock error for '{}': {}", video_id, e);
+            e.to_string()
+        })
 }
 
 #[tauri::command]
 async fn ping_proxy(proxy_url: String) -> Result<u128, String> {
     let mut client_builder = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5));
-        
+
     if !proxy_url.is_empty() {
-        if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-            client_builder = client_builder.proxy(proxy);
-        } else {
-            return Err("Invalid proxy URL format".into());
+        match reqwest::Proxy::all(&proxy_url) {
+            Ok(proxy) => client_builder = client_builder.proxy(proxy),
+            Err(e) => {
+                return Err(format!("Config error: invalid proxy URL: {}", e));
+            }
         }
     }
-    
-    let client = client_builder.build().map_err(|e| e.to_string())?;
-    
+
+    let client = client_builder
+        .build()
+        .map_err(|e| format!("Network error: {}", e))?;
+
     let start = std::time::Instant::now();
-    // Testing a very fast endpoint usually used for latency checks
     let res = client
         .get("http://gstatic.com/generate_204")
         .send()
         .await
-        .map_err(|e| format!("Proxy error: {}", e))?;
-        
+        .map_err(|e| {
+            if e.is_timeout() {
+                "Network error: proxy connection timed out".to_string()
+            } else if e.is_connect() {
+                "Network error: cannot connect through proxy".to_string()
+            } else {
+                format!("Network error: {}", e)
+            }
+        })?;
+
     if res.status().is_success() {
-        Ok(start.elapsed().as_millis())
+        let ms = start.elapsed().as_millis();
+        info!("Proxy ping: {} ms via {}", ms, proxy_url);
+        Ok(ms)
     } else {
-        Err(format!("HTTP Error: {}", res.status()))
+        Err(format!("API error: HTTP {}", res.status()))
     }
 }
 
@@ -128,7 +151,10 @@ async fn save_settings(
 ) -> Result<(), String> {
     let mut s = state.settings.lock().await;
     *s = new_settings.clone();
-    state.settings_manager.save(&new_settings)?;
+    state.settings_manager.save(&new_settings).map_err(|e| {
+        error!("Failed to save settings: {}", e);
+        e.to_string()
+    })?;
     Ok(())
 }
 
@@ -136,8 +162,11 @@ async fn save_settings(
 async fn save_yandex_token(token: String, state: State<'_, AppState>) -> Result<(), String> {
     let mut s = state.settings.lock().await;
     s.yandex_token = Some(token);
-    state.settings_manager.save(&s)?;
-    println!("✅ OAuth Token saved successfully!");
+    state.settings_manager.save(&s).map_err(|e| {
+        error!("Failed to save OAuth token: {}", e);
+        e.to_string()
+    })?;
+    info!("OAuth token saved successfully");
     Ok(())
 }
 
@@ -151,22 +180,21 @@ async fn translate(
 
     if current_settings.use_proxy {
         info!(
-            "Translate via Proxy ({}): {}",
+            "Translate via proxy ({}): {}",
             current_settings.proxy_url, url
         );
     } else {
-        info!("Translate via Direct Connection: {}", url);
+        info!("Translate via direct connection: {}", url);
     };
 
-    let result = state
+    state
         .yandex_translator
         .translate_video(&url, duration, &current_settings)
-        .await;
-
-    if let Err(e) = &result {
-        error!("Translate Error: {}", e);
-    }
-    result
+        .await
+        .map_err(|e| {
+            error!("Translation failed for '{}': {}", url, e);
+            e.to_string()
+        })
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -179,7 +207,9 @@ pub fn run() {
                 .level(log::LevelFilter::Info)
                 .clear_targets()
                 .target(Target::new(TargetKind::Stdout))
-                .target(Target::new(TargetKind::LogDir { file_name: Some("crabvoice.log".to_string()) }))
+                .target(Target::new(TargetKind::LogDir {
+                    file_name: Some("crabvoice.log".to_string()),
+                }))
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
@@ -198,7 +228,7 @@ pub fn run() {
         .setup(move |app| {
             let settings_manager = SettingsManager::new(app.handle());
             let settings = settings_manager.load();
-            info!("🦀 CrabVoice backend started");
+            info!("CrabVoice backend started (tier: {})", premium::get_tier());
 
             app.manage(AppState {
                 yandex_translator: Arc::new(YandexClient::new()),
@@ -206,7 +236,6 @@ pub fn run() {
                 settings_manager,
             });
 
-            // 3. Создаем окно
             let mut window_builder = tauri::WebviewWindowBuilder::new(
                 app,
                 "main",
@@ -218,10 +247,10 @@ pub fn run() {
                 match tauri::Url::parse(&settings.proxy_url) {
                     Ok(url) => {
                         window_builder = window_builder.proxy_url(url);
-                        info!("🌐 Webview Proxy enabled: {}", settings.proxy_url);
+                        info!("Webview proxy enabled: {}", settings.proxy_url);
                     }
                     Err(e) => {
-                        error!("❌ Invalid proxy URL: {}", e);
+                        warn!("Invalid proxy URL for webview: {}", e);
                     }
                 }
             }

--- a/src-tauri/src/premium.rs
+++ b/src-tauri/src/premium.rs
@@ -1,3 +1,4 @@
+use crate::error::AppError;
 use serde::Serialize;
 
 #[cfg(feature = "subscribers")]
@@ -25,7 +26,7 @@ pub fn get_tier() -> &'static str {
 // FREE: SponsorBlock is not available
 // --------------------------------------------------------
 #[cfg(not(feature = "subscribers"))]
-pub async fn fetch_sponsor_segments(_video_id: &str) -> Result<Vec<SponsorSegment>, String> {
+pub async fn fetch_sponsor_segments(_video_id: &str) -> Result<Vec<SponsorSegment>, AppError> {
     Ok(vec![])
 }
 
@@ -33,7 +34,9 @@ pub async fn fetch_sponsor_segments(_video_id: &str) -> Result<Vec<SponsorSegmen
 // SUBSCRIBERS+: Real SponsorBlock API integration
 // --------------------------------------------------------
 #[cfg(feature = "subscribers")]
-pub async fn fetch_sponsor_segments(video_id: &str) -> Result<Vec<SponsorSegment>, String> {
+pub async fn fetch_sponsor_segments(video_id: &str) -> Result<Vec<SponsorSegment>, AppError> {
+    use log::debug;
+
     #[derive(Deserialize)]
     struct ApiSegment {
         segment: [f32; 2],
@@ -46,22 +49,27 @@ pub async fn fetch_sponsor_segments(video_id: &str) -> Result<Vec<SponsorSegment
         r#"["sponsor","selfpromo","interaction","intro","outro"]"#
     );
 
-    let resp = reqwest::get(&url)
-        .await
-        .map_err(|e| format!("SponsorBlock request failed: {}", e))?;
+    let resp = reqwest::get(&url).await?;
 
     if resp.status() == 404 {
+        debug!("SponsorBlock: no segments for video {}", video_id);
         return Ok(vec![]);
     }
 
     if !resp.status().is_success() {
-        return Err(format!("SponsorBlock API error: {}", resp.status()));
+        return Err(AppError::Api(format!(
+            "SponsorBlock returned HTTP {}",
+            resp.status()
+        )));
     }
 
-    let api_segments: Vec<ApiSegment> = resp
-        .json()
-        .await
-        .map_err(|e| format!("SponsorBlock parse error: {}", e))?;
+    let api_segments: Vec<ApiSegment> = resp.json().await?;
+
+    debug!(
+        "SponsorBlock: loaded {} segments for video {}",
+        api_segments.len(),
+        video_id
+    );
 
     Ok(api_segments
         .into_iter()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,4 +1,6 @@
 use crate::domain::AppSettings;
+use crate::error::AppError;
+use log::{info, warn};
 use std::fs;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
@@ -9,31 +11,46 @@ pub struct SettingsManager {
 
 impl SettingsManager {
     pub fn new(app: &AppHandle) -> Self {
-        // Получаем правильный путь к папке данных приложения в зависимости от ОС (Windows/Mac/Android)
         let mut path = app
             .path()
             .app_data_dir()
             .expect("Failed to get app data dir");
 
-        // Создаем папку, если её нет
         if !path.exists() {
             let _ = fs::create_dir_all(&path);
         }
 
         path.push("settings.json");
+        info!("Settings path: {}", path.display());
         Self { filepath: path }
     }
 
     pub fn load(&self) -> AppSettings {
-        if let Ok(content) = fs::read_to_string(&self.filepath) {
-            serde_json::from_str(&content).unwrap_or_default()
-        } else {
-            AppSettings::default()
+        match fs::read_to_string(&self.filepath) {
+            Ok(content) => match serde_json::from_str(&content) {
+                Ok(settings) => {
+                    info!("Settings loaded from {}", self.filepath.display());
+                    settings
+                }
+                Err(e) => {
+                    warn!(
+                        "Settings file corrupted ({}), using defaults: {}",
+                        self.filepath.display(),
+                        e
+                    );
+                    AppSettings::default()
+                }
+            },
+            Err(_) => {
+                info!("No settings file found, using defaults");
+                AppSettings::default()
+            }
         }
     }
 
-    pub fn save(&self, settings: &AppSettings) -> Result<(), String> {
-        let content = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-        fs::write(&self.filepath, content).map_err(|e| e.to_string())
+    pub fn save(&self, settings: &AppSettings) -> Result<(), AppError> {
+        let content = serde_json::to_string_pretty(settings)?;
+        fs::write(&self.filepath, content)?;
+        Ok(())
     }
 }

--- a/src-tauri/src/yandex_api.rs
+++ b/src-tauri/src/yandex_api.rs
@@ -1,6 +1,8 @@
 use crate::domain::{AppSettings, TranslationProvider, TranslationResult};
+use crate::error::AppError;
 use async_trait::async_trait;
 use hmac::{Hmac, Mac};
+use log::{debug, warn};
 use prost::Message;
 use reqwest::{header, Client};
 use sha2::Sha256;
@@ -28,8 +30,7 @@ impl TranslationProvider for YandexClient {
         video_url: &str,
         duration: f64,
         settings: &AppSettings,
-    ) -> Result<TranslationResult, String> {
-        // 1. Используем настройки, выбранные юзером
+    ) -> Result<TranslationResult, AppError> {
         let request = pb::VideoTranslationRequest {
             url: video_url.to_string(),
             language: settings.default_source_lang.clone(),
@@ -45,46 +46,47 @@ impl TranslationProvider for YandexClient {
             ..Default::default()
         };
 
-        // 2. Сериализуем в бинарный формат
         let mut buf = Vec::new();
-        request.encode(&mut buf).map_err(|e| e.to_string())?;
+        request.encode(&mut buf)?;
 
-        // 3. Создаем криптографическую подпись (HMAC-SHA256)
         let mut mac =
             Hmac::<Sha256>::new_from_slice(HMAC_KEY).expect("HMAC can take key of any size");
         mac.update(&buf);
-        let signature_bytes = mac.finalize().into_bytes();
-        let signature_hex = hex::encode(signature_bytes); // Переводим в 16-ричную строку
-
-        // 4. Генерируем уникальный токен сессии (Яндекс это требует)
+        let signature_hex = hex::encode(mac.finalize().into_bytes());
         let uuid_str = Uuid::new_v4().to_string();
 
-        // 5. Собираем HTTP клиент Яндекса на лету
+        debug!(
+            "Yandex API: {} -> {}, duration={:.0}s, lively={}",
+            settings.default_source_lang, settings.default_target_lang, duration, settings.use_lively_voice
+        );
+
         let mut headers = header::HeaderMap::new();
         headers.insert(header::USER_AGENT, header::HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.836 YaBrowser/23.9.1.836 Yowser/2.5 Safari/537.36"));
-        headers.insert(
-            header::ACCEPT,
-            header::HeaderValue::from_static("application/x-protobuf"),
-        );
-        headers.insert(
-            header::CONTENT_TYPE,
-            header::HeaderValue::from_static("application/x-protobuf"),
-        );
+        headers.insert(header::ACCEPT, header::HeaderValue::from_static("application/x-protobuf"));
+        headers.insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/x-protobuf"));
 
         let mut client_builder = Client::builder().default_headers(headers);
 
-        // Применяем кастомный прокси, если включен
         if settings.use_proxy && !settings.proxy_url.is_empty() {
-            if let Ok(proxy) = reqwest::Proxy::all(&settings.proxy_url) {
-                client_builder = client_builder.proxy(proxy);
+            match reqwest::Proxy::all(&settings.proxy_url) {
+                Ok(proxy) => {
+                    debug!("Using proxy: {}", settings.proxy_url);
+                    client_builder = client_builder.proxy(proxy);
+                }
+                Err(e) => {
+                    warn!("Invalid proxy URL '{}': {}", settings.proxy_url, e);
+                    return Err(AppError::Config(format!(
+                        "Invalid proxy URL '{}': {}",
+                        settings.proxy_url, e
+                    )));
+                }
             }
         }
 
-        let client = client_builder
-            .build()
-            .map_err(|e| format!("Failed to build reqwest client: {}", e))?;
+        let client = client_builder.build().map_err(|e| {
+            AppError::Network(format!("Failed to create HTTP client: {}", e))
+        })?;
 
-        // 6. Отправляем POST запрос Яндексу
         let mut req_builder = client
             .post("https://api.browser.yandex.ru/video-translation/translate")
             .header("Vtrans-Signature", signature_hex)
@@ -95,24 +97,33 @@ impl TranslationProvider for YandexClient {
             req_builder = req_builder.header("Authorization", format!("OAuth {}", token));
         }
 
-        let response = req_builder
-            .send()
-            .await
-            .map_err(|e| format!("Network error: {}", e))?;
+        let response = req_builder.send().await.map_err(|e| {
+            if e.is_timeout() {
+                AppError::Network("Request timed out — check your connection or proxy".into())
+            } else if e.is_connect() {
+                AppError::Network("Cannot connect to Yandex API — check your network".into())
+            } else {
+                AppError::Network(e.to_string())
+            }
+        })?;
 
         if !response.status().is_success() {
             let status = response.status();
             let err_text = response.text().await.unwrap_or_default();
-            println!("❌ Yandex API Error: HTTP {} - {}", status, err_text);
-            return Err(format!("Yandex HTTP {}: {}", status, err_text));
+            warn!("Yandex API HTTP {}: {}", status, err_text);
+            return Err(AppError::Api(format!("Yandex HTTP {}", status)));
         }
 
-        // 4. Получаем бинарный ответ и десериализуем его
-        let response_bytes = response.bytes().await.map_err(|e| e.to_string())?;
-        let yandex_response = pb::VideoTranslationResponse::decode(response_bytes)
-            .map_err(|e| format!("Failed to decode protobuf: {}", e))?;
+        let response_bytes = response.bytes().await?;
+        let yandex_response = pb::VideoTranslationResponse::decode(response_bytes)?;
 
-        // 5. Мапим ответ Яндекса в нашу доменную сущность
+        debug!(
+            "Yandex response: status={}, url={}, remaining_time={:?}",
+            yandex_response.status,
+            yandex_response.url.as_deref().unwrap_or("none"),
+            yandex_response.remaining_time
+        );
+
         Ok(TranslationResult {
             url: yandex_response.url,
             status: yandex_response.status,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CrabVoice",
-  "version": "0.3.3",
+  "version": "0.5.0",
   "identifier": "com.zenonel.crabvoice",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -270,10 +270,15 @@ if (!window._cvInitialized) {
                         }, 1000);
                     }
                 } catch (e: any) {
-                    // Выводим ТОЧНУЮ причину ошибки из Rust
-                    appLog(`Rust Error: ${e.toString()}`);
-                    console.error("CrabVoice Rust Error:", e);
-                    updateStatus(e.toString().substring(0, 30) + " ⚠️", "#ff5e5e");
+                    const errStr = e?.toString() ?? '';
+                    appLog(`Backend error: ${errStr}`);
+                    // Map structured error categories to user-friendly i18n messages
+                    let userMsg = t('error.unknown');
+                    if (errStr.startsWith('Network error')) userMsg = t('error.network');
+                    else if (errStr.startsWith('API error')) userMsg = t('error.api');
+                    else if (errStr.startsWith('Parse error')) userMsg = t('error.parse');
+                    else if (errStr.startsWith('Config error')) userMsg = t('error.config');
+                    updateStatus(userMsg + " ⚠️", "#ff5e5e");
                     isTranslating = false;
                 }
             };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Real-time Native Video Translation",
-  "app.version": "CrabVoice v0.3.3 Public Beta",
+  "app.version": "CrabVoice v0.5.0 Public Beta",
   "app.crafted_by": "Crafted with 🦀 by",
 
   "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,5 +61,14 @@
   "status.parse_error": "VOT.js Parse Error ❌",
   "status.skipped": "Skipped {category} ⏩",
   "status.login_success": "Login successful!",
-  "status.returning": "Returning to CrabVoice..."
+  "status.returning": "Returning to CrabVoice...",
+
+  "error.network": "Connection failed — check your network",
+  "error.api": "Translation service error",
+  "error.parse": "Unexpected response from server",
+  "error.config": "Configuration error",
+  "error.io": "File operation failed",
+  "error.unknown": "Something went wrong",
+  "error.settings_save": "Failed to save settings",
+  "error.settings_load": "Failed to load settings"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Нативный голосовой перевод видео",
-  "app.version": "CrabVoice v0.3.3 Публичная бета",
+  "app.version": "CrabVoice v0.5.0 Публичная бета",
   "app.crafted_by": "Сделано с 🦀 от",
 
   "url.placeholder": "Вставьте ссылку на видео (YouTube, VK, Vimeo)...",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -61,5 +61,14 @@
   "status.parse_error": "Ошибка VOT.js ❌",
   "status.skipped": "Пропущено: {category} ⏩",
   "status.login_success": "Вход выполнен!",
-  "status.returning": "Возврат в CrabVoice..."
+  "status.returning": "Возврат в CrabVoice...",
+
+  "error.network": "Ошибка подключения — проверьте сеть",
+  "error.api": "Ошибка сервиса перевода",
+  "error.parse": "Неожиданный ответ от сервера",
+  "error.config": "Ошибка конфигурации",
+  "error.io": "Ошибка файловой операции",
+  "error.unknown": "Что-то пошло не так",
+  "error.settings_save": "Не удалось сохранить настройки",
+  "error.settings_load": "Не удалось загрузить настройки"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,7 +186,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         e.preventDefault();
         if (urlInputEl.value) {
             console.log(`Requested translation for: ${urlInputEl.value}`);
-            resultMsgEl.innerHTML = `<span style="color: #4CAF50;">${Icons.videoRedirectShow} ${t('url.redirecting')}</span>`;
+            resultMsgEl.innerHTML = `<span style="color: #4CAF50;"${Icons.videoRedirectShow} ${t('url.redirecting')}</span>`;
             window.location.href = urlInputEl.value;
         }
     });


### PR DESCRIPTION
- Create AppError enum with categories: Network, Api, Parse, Config, Io
- Add From impls for std::io::Error, serde_json, reqwest, prost errors
- Update TranslationProvider trait to return Result<T, AppError>
- Refactor yandex_api.rs with AppError + descriptive messages for
  timeout/connect/proxy failures
- Refactor settings.rs with AppError + load/save logging
- Refactor premium.rs with AppError + debug logging for SponsorBlock
- Update lib.rs: log errors at IPC boundary before converting to String
- Frontend: map error categories to user-friendly i18n messages
- Add i18n keys for error categories (en + ru)