### PR TITLE
Switch to Yandex OAuth Device Code Flow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ dist-ssr
 /src-tauri/gen
 src-tauri/injector.js
 /.claude
+.env
+src-tauri/.env

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
         <div class="app-footer">
             <p><span data-i18n="app.crafted_by">Crafted with 🦀 by</span> <a href="https://github.com/ZenonEl" target="_blank">ZenonEl</a></p>
-            <p class="version-info" data-i18n="app.version">CrabVoice v0.5.0 Public Beta</p>
+            <p class="version-info" data-i18n="app.version">CrabVoice v0.6.0 Public Beta</p>
             <p style="font-size:10px;color:#555;margin-top:4px;">(Using <a href="https://sponsor.ajay.app/" style="color:#777;">SponsorBlock</a> data under CC BY-NC-SA 4.0)</p>
 
             <!-- Socials -->

--- a/index.html
+++ b/index.html
@@ -69,6 +69,12 @@
                 </button>
             </div>
             <div id="auth-status" style="font-size:12px; color:#aaa; text-align:right;"></div>
+            <div id="device-code-flow" style="display:none; margin-top:10px; padding:12px; background:rgba(255,255,255,0.05); border-radius:8px; text-align:center;">
+                <p style="margin:0 0 8px; font-size:13px; color:#aaa;" data-i18n="auth.enter_code">Enter this code on the page:</p>
+                <div id="device-user-code" style="font-size:28px; font-weight:bold; letter-spacing:4px; color:#24c8db; margin:8px 0;"></div>
+                <button id="btn-open-device-page" class="btn-primary" style="margin:8px 0; width:100%;"><span data-i18n="auth.open_yandex_device">Open yandex.ru/device</span></button>
+                <div id="device-status" style="font-size:12px; color:#FFC131; margin-top:6px;"></div>
+            </div>
 
             <div class="setting-group row-checkbox">
                 <input type="checkbox" id="set-use-proxy" />

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CrabVoice",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "CrabVoice"
-version = "0.5.0"
+version = "0.6.0"
 description = "Cross-platform real-time voice-over translation app for video platforms. Features native audio sync, vot.js integration, and mobile support"
 authors = ["Zenonel"]
 edition = "2021"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,18 @@
 fn main() {
+    // Load .env and pass variables to rustc at compile time
+    if let Ok(content) = std::fs::read_to_string(".env") {
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once('=') {
+                println!("cargo:rustc-env={}={}", key.trim(), value.trim());
+            }
+        }
+        println!("cargo:rerun-if-changed=.env");
+    }
+
     // Компилируем наш proto файл. Он сгенерирует Rust-код в папку target/OUT_DIR
     prost_build::compile_protos(&["proto/yandex.proto"], &["proto/"])
         .expect("Failed to compile Protobuf");

--- a/src-tauri/injector.js
+++ b/src-tauri/injector.js
@@ -3585,7 +3585,7 @@
   var en_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "Real-time Native Video Translation",
-    "app.version": "CrabVoice v0.5.0 Public Beta",
+    "app.version": "CrabVoice v0.6.0 Public Beta",
     "app.crafted_by": "Crafted with \u{1F980} by",
     "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",
     "url.open": "Open Video",
@@ -3638,14 +3638,22 @@
     "status.parse_error": "VOT.js Parse Error \u274C",
     "status.skipped": "Skipped {category} \u23E9",
     "status.login_success": "Login successful!",
-    "status.returning": "Returning to CrabVoice..."
+    "status.returning": "Returning to CrabVoice...",
+    "error.network": "Connection failed \u2014 check your network",
+    "error.api": "Translation service error",
+    "error.parse": "Unexpected response from server",
+    "error.config": "Configuration error",
+    "error.io": "File operation failed",
+    "error.unknown": "Something went wrong",
+    "error.settings_save": "Failed to save settings",
+    "error.settings_load": "Failed to load settings"
   };
 
   // src/locales/ru.json
   var ru_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "\u041D\u0430\u0442\u0438\u0432\u043D\u044B\u0439 \u0433\u043E\u043B\u043E\u0441\u043E\u0432\u043E\u0439 \u043F\u0435\u0440\u0435\u0432\u043E\u0434 \u0432\u0438\u0434\u0435\u043E",
-    "app.version": "CrabVoice v0.5.0 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
+    "app.version": "CrabVoice v0.6.0 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
     "app.crafted_by": "\u0421\u0434\u0435\u043B\u0430\u043D\u043E \u0441 \u{1F980} \u043E\u0442",
     "url.placeholder": "\u0412\u0441\u0442\u0430\u0432\u044C\u0442\u0435 \u0441\u0441\u044B\u043B\u043A\u0443 \u043D\u0430 \u0432\u0438\u0434\u0435\u043E (YouTube, VK, Vimeo)...",
     "url.open": "\u041E\u0442\u043A\u0440\u044B\u0442\u044C \u0432\u0438\u0434\u0435\u043E",
@@ -3698,7 +3706,15 @@
     "status.parse_error": "\u041E\u0448\u0438\u0431\u043A\u0430 VOT.js \u274C",
     "status.skipped": "\u041F\u0440\u043E\u043F\u0443\u0449\u0435\u043D\u043E: {category} \u23E9",
     "status.login_success": "\u0412\u0445\u043E\u0434 \u0432\u044B\u043F\u043E\u043B\u043D\u0435\u043D!",
-    "status.returning": "\u0412\u043E\u0437\u0432\u0440\u0430\u0442 \u0432 CrabVoice..."
+    "status.returning": "\u0412\u043E\u0437\u0432\u0440\u0430\u0442 \u0432 CrabVoice...",
+    "error.network": "\u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u044F \u2014 \u043F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u0441\u0435\u0442\u044C",
+    "error.api": "\u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0438\u0441\u0430 \u043F\u0435\u0440\u0435\u0432\u043E\u0434\u0430",
+    "error.parse": "\u041D\u0435\u043E\u0436\u0438\u0434\u0430\u043D\u043D\u044B\u0439 \u043E\u0442\u0432\u0435\u0442 \u043E\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430",
+    "error.config": "\u041E\u0448\u0438\u0431\u043A\u0430 \u043A\u043E\u043D\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u0438",
+    "error.io": "\u041E\u0448\u0438\u0431\u043A\u0430 \u0444\u0430\u0439\u043B\u043E\u0432\u043E\u0439 \u043E\u043F\u0435\u0440\u0430\u0446\u0438\u0438",
+    "error.unknown": "\u0427\u0442\u043E-\u0442\u043E \u043F\u043E\u0448\u043B\u043E \u043D\u0435 \u0442\u0430\u043A",
+    "error.settings_save": "\u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0441\u043E\u0445\u0440\u0430\u043D\u0438\u0442\u044C \u043D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438",
+    "error.settings_load": "\u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044C \u043D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438"
   };
 
   // src/i18n.ts
@@ -4298,9 +4314,14 @@ ${a.stack}`;
               }, 1e3);
             }
           } catch (e) {
-            appLog(`Rust Error: ${e.toString()}`);
-            console.error("CrabVoice Rust Error:", e);
-            updateStatus(e.toString().substring(0, 30) + " \u26A0\uFE0F", "#ff5e5e");
+            const errStr = e?.toString() ?? "";
+            appLog(`Backend error: ${errStr}`);
+            let userMsg = t("error.unknown");
+            if (errStr.startsWith("Network error")) userMsg = t("error.network");
+            else if (errStr.startsWith("API error")) userMsg = t("error.api");
+            else if (errStr.startsWith("Parse error")) userMsg = t("error.parse");
+            else if (errStr.startsWith("Config error")) userMsg = t("error.config");
+            updateStatus(userMsg + " \u26A0\uFE0F", "#ff5e5e");
             isTranslating = false;
           }
         };

--- a/src-tauri/injector.js
+++ b/src-tauri/injector.js
@@ -3610,6 +3610,12 @@
     "auth.authorized": "\u2705 Authorized",
     "auth.not_authorized": "\u274C Not authorized",
     "auth.redirecting": "Redirecting to Yandex...",
+    "auth.requesting_code": "Requesting code...",
+    "auth.waiting_for_auth": "Waiting for authorization...",
+    "auth.code_expired": "\u274C Code expired \u2014 try again",
+    "auth.code_request_failed": "\u274C Failed to get code",
+    "auth.enter_code": "Enter this code on the page:",
+    "auth.open_yandex_device": "Open yandex.ru/device",
     "logs.title": "App Logs",
     "logs.view": "View Logs",
     "logs.export": "Export / Copy Logs",
@@ -3678,6 +3684,12 @@
     "auth.authorized": "\u2705 \u0410\u0432\u0442\u043E\u0440\u0438\u0437\u043E\u0432\u0430\u043D",
     "auth.not_authorized": "\u274C \u041D\u0435 \u0430\u0432\u0442\u043E\u0440\u0438\u0437\u043E\u0432\u0430\u043D",
     "auth.redirecting": "\u041F\u0435\u0440\u0435\u043D\u0430\u043F\u0440\u0430\u0432\u043B\u0435\u043D\u0438\u0435 \u043D\u0430 \u042F\u043D\u0434\u0435\u043A\u0441...",
+    "auth.requesting_code": "\u0417\u0430\u043F\u0440\u043E\u0441 \u043A\u043E\u0434\u0430...",
+    "auth.waiting_for_auth": "\u041E\u0436\u0438\u0434\u0430\u043D\u0438\u0435 \u0430\u0432\u0442\u043E\u0440\u0438\u0437\u0430\u0446\u0438\u0438...",
+    "auth.code_expired": "\u274C \u041A\u043E\u0434 \u0438\u0441\u0442\u0451\u043A \u2014 \u043F\u043E\u043F\u0440\u043E\u0431\u0443\u0439\u0442\u0435 \u0441\u043D\u043E\u0432\u0430",
+    "auth.code_request_failed": "\u274C \u041D\u0435 \u0443\u0434\u0430\u043B\u043E\u0441\u044C \u043F\u043E\u043B\u0443\u0447\u0438\u0442\u044C \u043A\u043E\u0434",
+    "auth.enter_code": "\u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044D\u0442\u043E\u0442 \u043A\u043E\u0434 \u043D\u0430 \u0441\u0442\u0440\u0430\u043D\u0438\u0446\u0435:",
+    "auth.open_yandex_device": "\u041E\u0442\u043A\u0440\u044B\u0442\u044C yandex.ru/device",
     "logs.title": "\u041B\u043E\u0433\u0438 \u043F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u044F",
     "logs.view": "\u041F\u0440\u043E\u0441\u043C\u043E\u0442\u0440 \u043B\u043E\u0433\u043E\u0432",
     "logs.export": "\u042D\u043A\u0441\u043F\u043E\u0440\u0442 / \u041A\u043E\u043F\u0438\u0440\u043E\u0432\u0430\u0442\u044C",
@@ -4138,25 +4150,6 @@ ${a.stack}`;
     }).join(" ");
     invokeLog("error", msg);
   };
-  if (window.location.href.includes("access_token=")) {
-    const hashOrSearch = window.location.hash ? window.location.hash.replace(/^#/, "") : window.location.search.replace(/^\?/, "");
-    const params = new URLSearchParams(hashOrSearch);
-    const token = params.get("access_token");
-    if (token && window.__TAURI__) {
-      try {
-        window.stop();
-      } catch (e) {
-      }
-      document.documentElement.innerHTML = `<body style='background:#121212;'><h2 style='color: #4CAF50; text-align: center; margin-top: 50px; font-family: sans-serif;'>${Icons.done} ${t("status.login_success")}<br><br><span style='color: #aaa; font-size: 16px;'>${t("status.returning")}</span></h2></body>`;
-      window.__TAURI__.core.invoke("save_yandex_token", { token }).then(() => {
-        const homeUrl = localStorage.getItem("cv_home_url");
-        setTimeout(() => {
-          if (homeUrl) window.location.href = homeUrl;
-          else window.history.go(-(window.history.length - 1));
-        }, 1e3);
-      });
-    }
-  }
   if (!window._cvInitialized) {
     let updateStatus = function(text, color) {
       if (panelInstance) {
@@ -4196,10 +4189,11 @@ ${a.stack}`;
     updateStatus2 = updateStatus, syncAudio2 = syncAudio;
     window._cvInitialized = true;
     const isHome = window.location.hostname === "localhost" || window.location.hostname === "tauri.localhost" || window.location.protocol === "tauri:";
-    if (isHome) {
-      localStorage.setItem("cv_home_url", window.location.href);
-    } else {
-      appLog(`CrabVoice Injector attached to ${window.location.hostname}`);
+    const skipDomains = ["oauth.yandex.", "passport.yandex.", "accounts.google.", "login.yandex.", "sso.yandex."];
+    const hostname = window.location.hostname;
+    const shouldSkipInjection = isHome || skipDomains.some((d) => hostname.includes(d));
+    if (!isHome) {
+      appLog(`CrabVoice Injector attached to ${window.location.hostname}${shouldSkipInjection ? " (skip mode)" : ""}`);
     }
     let mainVideo = null;
     let audioObj = null;
@@ -4361,7 +4355,7 @@ ${a.stack}`;
       });
     }
     const checkAndInject = () => {
-      if (isHome) return;
+      if (shouldSkipInjection) return;
       if (mainVideo && (!mainVideo.isConnected || window.location.href !== currentVideoUrl)) {
         mainVideo = null;
         if (audioObj) {
@@ -4379,9 +4373,7 @@ ${a.stack}`;
       if (!panelHost && !panelInstance) {
         panelInstance = new CrabPanel({
           onClose: () => {
-            const homeUrl = localStorage.getItem("cv_home_url");
-            if (homeUrl) window.location.href = homeUrl;
-            else window.history.go(-(window.history.length - 1));
+            history.back();
           },
           onAudioVolume: (val) => {
             userAudioVolume = val;

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -58,6 +58,25 @@ pub struct TranslationResult {
     pub remaining_time: Option<i32>,
 }
 
+/// Response from Yandex OAuth Device Code request
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_url: String,
+    pub interval: u64,
+    pub expires_in: u64,
+}
+
+/// Response from Yandex OAuth token polling
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeviceTokenResponse {
+    pub access_token: Option<String>,
+    pub token_type: Option<String>,
+    pub expires_in: Option<u64>,
+    pub error: Option<String>,
+}
+
 /// Порт (Интерфейс) для инверсии зависимостей.
 #[async_trait]
 pub trait TranslationProvider: Send + Sync {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,7 +241,17 @@ pub fn run() {
                 "main",
                 tauri::WebviewUrl::App("index.html".into()),
             )
-            .initialization_script(init_script);
+            .initialization_script(init_script)
+            .on_navigation(|url| {
+                let url_str = url.as_str();
+                // Block non-http(s) schemes (yandexauth://, intent://, etc.)
+                // These cause white screen on Android webview
+                if !url_str.starts_with("http://") && !url_str.starts_with("https://") && !url_str.starts_with("tauri://") {
+                    warn!("Blocked navigation to unsupported scheme: {}", url_str);
+                    return false;
+                }
+                true
+            });
 
             if settings.use_proxy && !settings.proxy_url.is_empty() {
                 match tauri::Url::parse(&settings.proxy_url) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod premium;
 mod settings;
 mod yandex_api;
 
-use domain::{AppSettings, TranslationProvider, TranslationResult};
+use domain::{AppSettings, DeviceCodeResponse, DeviceTokenResponse, TranslationProvider, TranslationResult};
 use settings::SettingsManager;
 use yandex_api::YandexClient;
 
@@ -14,6 +14,9 @@ use std::sync::Arc;
 use tauri::{Manager, State};
 use tauri_plugin_log::{Target, TargetKind};
 use tokio::sync::Mutex;
+
+const YANDEX_CLIENT_ID: &str = env!("YANDEX_CLIENT_ID");
+const YANDEX_CLIENT_SECRET: &str = env!("YANDEX_CLIENT_SECRET");
 
 struct AppState {
     yandex_translator: Arc<dyn TranslationProvider>,
@@ -171,6 +174,49 @@ async fn save_yandex_token(token: String, state: State<'_, AppState>) -> Result<
 }
 
 #[tauri::command]
+async fn request_device_code() -> Result<DeviceCodeResponse, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://oauth.yandex.com/device/code")
+        .form(&[("client_id", YANDEX_CLIENT_ID)])
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: HTTP {} — {}", status, body));
+    }
+
+    let code_resp: DeviceCodeResponse = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+    info!("Device code requested, user_code: {}", code_resp.user_code);
+    Ok(code_resp)
+}
+
+#[tauri::command]
+async fn poll_device_token(device_code: String) -> Result<DeviceTokenResponse, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://oauth.yandex.com/token")
+        .form(&[
+            ("grant_type", "device_code"),
+            ("code", &device_code),
+            ("client_id", YANDEX_CLIENT_ID),
+            ("client_secret", YANDEX_CLIENT_SECRET),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {}", e))?;
+
+    let token_resp: DeviceTokenResponse = resp.json().await.map_err(|e| format!("Parse error: {}", e))?;
+    if let Some(ref token) = token_resp.access_token {
+        info!("Device code flow: token obtained (len={})", token.len());
+    }
+    Ok(token_resp)
+}
+
+#[tauri::command]
 async fn translate(
     url: String,
     duration: f64,
@@ -223,7 +269,9 @@ pub fn run() {
             export_logs,
             get_app_tier,
             get_skip_segments,
-            ping_proxy
+            ping_proxy,
+            request_device_code,
+            poll_device_token
         ])
         .setup(move |app| {
             let settings_manager = SettingsManager::new(app.handle());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CrabVoice",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.zenonel.crabvoice",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -80,8 +80,14 @@ if (!window._cvInitialized) {
     window._cvInitialized = true;
 
     const isHome = window.location.hostname === 'localhost' || window.location.hostname === 'tauri.localhost' || window.location.protocol === 'tauri:';
+
+    // Skip injection on pages where vot.js/panel are not needed
+    // OAuth pages, auth pages, etc. — injecting vot.js here causes webview hangs on Android
+    const skipHosts = ['oauth.yandex.ru', 'passport.yandex.ru', 'accounts.google.com'];
+    const shouldSkipInjection = isHome || skipHosts.some(h => window.location.hostname.includes(h));
+
     if (!isHome) {
-        appLog(`CrabVoice Injector attached to ${window.location.hostname}`);
+        appLog(`CrabVoice Injector attached to ${window.location.hostname}${shouldSkipInjection ? ' (skip mode)' : ''}`);
     }
 
     let mainVideo: HTMLVideoElement | null = null;
@@ -336,7 +342,7 @@ if (!window._cvInitialized) {
     }
 
     const checkAndInject = () => {
-        if (isHome) return;
+        if (shouldSkipInjection) return;
 
         if (mainVideo && (!mainVideo.isConnected || window.location.href !== currentVideoUrl)) {
             mainVideo = null;

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -53,17 +53,25 @@ if (window.location.href.includes('access_token=')) {
     const hashOrSearch = window.location.hash ? window.location.hash.replace(/^#/, '') : window.location.search.replace(/^\?/, '');
     const params = new URLSearchParams(hashOrSearch);
     const token = params.get('access_token');
-    
+
     if (token && window.__TAURI__) {
-        try { window.stop(); } catch(e){} // Стопаем загрузку страницы Яндекса
+        try { window.stop(); } catch(e){}
         document.documentElement.innerHTML = `<body style='background:#121212;'><h2 style='color: #4CAF50; text-align: center; margin-top: 50px; font-family: sans-serif;'>${Icons.done} ${t('status.login_success')}<br><br><span style='color: #aaa; font-size: 16px;'>${t('status.returning')}</span></h2></body>`;
-        
+
         window.__TAURI__.core.invoke('save_yandex_token', { token: token }).then(() => {
-            const homeUrl = localStorage.getItem('cv_home_url');
             setTimeout(() => {
-                if (homeUrl) window.location.href = homeUrl;
-                else window.history.go(-(window.history.length - 1));
+                // Navigate to home — use known Tauri home URLs
+                // localStorage is per-origin, so cv_home_url is NOT accessible from oauth.yandex.ru
+                // Use tauri:// or localhost directly, with replace() to avoid bfcache
+                if (window.location.protocol === 'tauri:') {
+                    window.location.replace('tauri://localhost');
+                } else {
+                    window.location.replace('http://localhost:1420');
+                }
             }, 1000);
+        }).catch(() => {
+            // Token save failed — still try to go home
+            window.location.replace('http://localhost:1420');
         });
     }
 }
@@ -72,9 +80,7 @@ if (!window._cvInitialized) {
     window._cvInitialized = true;
 
     const isHome = window.location.hostname === 'localhost' || window.location.hostname === 'tauri.localhost' || window.location.protocol === 'tauri:';
-    if (isHome) {
-        localStorage.setItem('cv_home_url', window.location.href);
-    } else {
+    if (!isHome) {
         appLog(`CrabVoice Injector attached to ${window.location.hostname}`);
     }
 
@@ -344,9 +350,11 @@ if (!window._cvInitialized) {
         if (!panelHost && !panelInstance) {
             panelInstance = new CrabPanel({
                 onClose: () => {
-                    const homeUrl = localStorage.getItem('cv_home_url');
-                    if (homeUrl) window.location.href = homeUrl;
-                    else window.history.go(-(window.history.length - 1));
+                    if (window.location.protocol === 'tauri:') {
+                        window.location.replace('tauri://localhost');
+                    } else {
+                        window.location.replace('http://localhost:1420');
+                    }
                 },
                 onAudioVolume: (val: number) => {
                     userAudioVolume = val;

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -1,7 +1,6 @@
 import { getService, getVideoData } from "@vot.js/ext/utils/videoData";  
 import type { ServiceConf } from "@vot.js/ext/types/service";
 import { CrabPanel, type AppTier } from "./injectorPanel";
-import { Icons } from "./icons";
 import { t, setLocale, type Locale } from "./i18n";
 
 // Универсальная функция отправки логов из песочницы инжектора в Rust
@@ -35,6 +34,7 @@ declare global {
             core: { invoke(cmd: string, args?: any): Promise<any>; };
         };
         _cvInitialized?: boolean;
+        _cvHomeUrl?: string;
         trustedTypes?: any;
         _cvPolicy?: any;
     }
@@ -48,43 +48,17 @@ interface AppSettings {
     ui_language: string;
 }
 
-// Перехват OAuth редиректа от сервера Яндекса
-if (window.location.href.includes('access_token=')) {
-    const hashOrSearch = window.location.hash ? window.location.hash.replace(/^#/, '') : window.location.search.replace(/^\?/, '');
-    const params = new URLSearchParams(hashOrSearch);
-    const token = params.get('access_token');
-
-    if (token && window.__TAURI__) {
-        try { window.stop(); } catch(e){}
-        document.documentElement.innerHTML = `<body style='background:#121212;'><h2 style='color: #4CAF50; text-align: center; margin-top: 50px; font-family: sans-serif;'>${Icons.done} ${t('status.login_success')}<br><br><span style='color: #aaa; font-size: 16px;'>${t('status.returning')}</span></h2></body>`;
-
-        window.__TAURI__.core.invoke('save_yandex_token', { token: token }).then(() => {
-            setTimeout(() => {
-                // Navigate to home — use known Tauri home URLs
-                // localStorage is per-origin, so cv_home_url is NOT accessible from oauth.yandex.ru
-                // Use tauri:// or localhost directly, with replace() to avoid bfcache
-                if (window.location.protocol === 'tauri:') {
-                    window.location.replace('tauri://localhost');
-                } else {
-                    window.location.replace('http://localhost:1420');
-                }
-            }, 1000);
-        }).catch(() => {
-            // Token save failed — still try to go home
-            window.location.replace('http://localhost:1420');
-        });
-    }
-}
-
 if (!window._cvInitialized) {
     window._cvInitialized = true;
 
     const isHome = window.location.hostname === 'localhost' || window.location.hostname === 'tauri.localhost' || window.location.protocol === 'tauri:';
 
-    // Skip injection on pages where vot.js/panel are not needed
-    // OAuth pages, auth pages, etc. — injecting vot.js here causes webview hangs on Android
-    const skipHosts = ['oauth.yandex.ru', 'passport.yandex.ru', 'accounts.google.com'];
-    const shouldSkipInjection = isHome || skipHosts.some(h => window.location.hostname.includes(h));
+
+    // Skip vot.js/CrabPanel injection on non-video pages
+    // OAuth/auth pages cause webview hangs on Android when vot.js walks the DOM
+    const skipDomains = ['oauth.yandex.', 'passport.yandex.', 'accounts.google.', 'login.yandex.', 'sso.yandex.'];
+    const hostname = window.location.hostname;
+    const shouldSkipInjection = isHome || skipDomains.some(d => hostname.includes(d));
 
     if (!isHome) {
         appLog(`CrabVoice Injector attached to ${window.location.hostname}${shouldSkipInjection ? ' (skip mode)' : ''}`);
@@ -356,11 +330,7 @@ if (!window._cvInitialized) {
         if (!panelHost && !panelInstance) {
             panelInstance = new CrabPanel({
                 onClose: () => {
-                    if (window.location.protocol === 'tauri:') {
-                        window.location.replace('tauri://localhost');
-                    } else {
-                        window.location.replace('http://localhost:1420');
-                    }
+                    history.back();
                 },
                 onAudioVolume: (val: number) => {
                     userAudioVolume = val;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,6 +29,12 @@
   "auth.authorized": "✅ Authorized",
   "auth.not_authorized": "❌ Not authorized",
   "auth.redirecting": "Redirecting to Yandex...",
+  "auth.requesting_code": "Requesting code...",
+  "auth.waiting_for_auth": "Waiting for authorization...",
+  "auth.code_expired": "❌ Code expired — try again",
+  "auth.code_request_failed": "❌ Failed to get code",
+  "auth.enter_code": "Enter this code on the page:",
+  "auth.open_yandex_device": "Open yandex.ru/device",
 
   "logs.title": "App Logs",
   "logs.view": "View Logs",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Real-time Native Video Translation",
-  "app.version": "CrabVoice v0.5.0 Public Beta",
+  "app.version": "CrabVoice v0.6.0 Public Beta",
   "app.crafted_by": "Crafted with 🦀 by",
 
   "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -29,6 +29,12 @@
   "auth.authorized": "✅ Авторизован",
   "auth.not_authorized": "❌ Не авторизован",
   "auth.redirecting": "Перенаправление на Яндекс...",
+  "auth.requesting_code": "Запрос кода...",
+  "auth.waiting_for_auth": "Ожидание авторизации...",
+  "auth.code_expired": "❌ Код истёк — попробуйте снова",
+  "auth.code_request_failed": "❌ Не удалось получить код",
+  "auth.enter_code": "Введите этот код на странице:",
+  "auth.open_yandex_device": "Открыть yandex.ru/device",
 
   "logs.title": "Логи приложения",
   "logs.view": "Просмотр логов",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Нативный голосовой перевод видео",
-  "app.version": "CrabVoice v0.5.0 Публичная бета",
+  "app.version": "CrabVoice v0.6.0 Публичная бета",
   "app.crafted_by": "Сделано с 🦀 от",
 
   "url.placeholder": "Вставьте ссылку на видео (YouTube, VK, Vimeo)...",

--- a/src/main.ts
+++ b/src/main.ts
@@ -249,5 +249,18 @@ window.addEventListener("DOMContentLoaded", async () => {
         }
     });
 
+    // Handle bfcache restore (e.g. after OAuth redirect via history.back)
+    // DOMContentLoaded does NOT fire when page is restored from bfcache
+    window.addEventListener("pageshow", async (event) => {
+        if (event.persisted) {
+            console.log("Page restored from bfcache, refreshing auth status");
+            try {
+                const settings: AppSettings = await invoke("get_settings");
+                isAuthorized = !!settings.yandex_token;
+                updateAuthStatus();
+            } catch (_) {}
+        }
+    });
+
     console.log("Main UI loaded successfully");
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ interface AppSettings {
     sponsorblock_enabled: boolean;
     ui_language: string;
     theme: string;
+    yandex_token?: string;
 }
 
 function applyTheme(theme: string) {
@@ -61,6 +62,19 @@ window.addEventListener("DOMContentLoaded", async () => {
     const btnDownloadLogs = document.querySelector("#btn-download-logs") as HTMLButtonElement;
     const logsArea = document.querySelector("#logs-area") as HTMLTextAreaElement;
 
+    // Auth state tracked explicitly (not via CSS color)
+    let isAuthorized = false;
+
+    function updateAuthStatus() {
+        if (isAuthorized) {
+            authStatus.innerText = t('auth.authorized');
+            authStatus.style.color = "#4CAF50";
+        } else {
+            authStatus.innerText = t('auth.not_authorized');
+            authStatus.style.color = "#aaa";
+        }
+    }
+
     // Check app tier
     try {
         const tier = await invoke("get_app_tier") as string;
@@ -72,18 +86,9 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     // Load settings
     try {
-        // @ts-ignore - yandex_token added in backend
-        const settings: AppSettings & { yandex_token?: string } = await invoke("get_settings");
+        const settings: AppSettings = await invoke("get_settings");
 
-        targetLang.value = settings.default_target_lang;
-        volDucking.value = (settings.volume_ducking * 100).toString();
-        volVal.innerText = `${volDucking.value}%`;
-        livelyVoice.checked = settings.use_lively_voice;
-        useProxy.checked = settings.use_proxy;
-        proxyHost.value = settings.proxy_url;
-        proxyContainer.style.display = useProxy.checked ? "flex" : "none";
-
-        // Apply i18n
+        // Apply i18n first (so t() calls below use correct locale)
         const locale = (settings.ui_language || 'en') as Locale;
         uiLanguage.value = locale;
         setLocale(locale);
@@ -93,12 +98,18 @@ window.addEventListener("DOMContentLoaded", async () => {
         themeSelect.value = theme;
         applyTheme(theme);
 
-        if (settings.yandex_token) {
-            authStatus.innerText = t('auth.authorized');
-            authStatus.style.color = "#4CAF50";
-        } else {
-            authStatus.innerText = t('auth.not_authorized');
-        }
+        // Apply settings to UI
+        targetLang.value = settings.default_target_lang;
+        volDucking.value = (settings.volume_ducking * 100).toString();
+        volVal.innerText = `${volDucking.value}%`;
+        livelyVoice.checked = settings.use_lively_voice;
+        useProxy.checked = settings.use_proxy;
+        proxyHost.value = settings.proxy_url;
+        proxyContainer.style.display = useProxy.checked ? "flex" : "none";
+
+        // Auth status
+        isAuthorized = !!settings.yandex_token;
+        updateAuthStatus();
     } catch (e) {
         console.error("Failed to load settings:", e);
     }
@@ -107,13 +118,14 @@ window.addEventListener("DOMContentLoaded", async () => {
     btnLogin.addEventListener("click", (e) => {
         e.preventDefault();
         authStatus.innerText = t('auth.redirecting');
+        authStatus.style.color = "#FFC131";
         window.location.href = "https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d";
     });
 
-    // Save settings helper
+    // Save settings helper — loads current settings first to preserve fields not in UI
     const saveSettings = async () => {
-        let currentSettings: any = {};
-        try { currentSettings = await invoke("get_settings"); } catch (_) {}
+        let current: AppSettings | null = null;
+        try { current = await invoke("get_settings"); } catch (_) {}
         const newSettings: AppSettings = {
             volume_ducking: parseInt(volDucking.value) / 100.0,
             default_source_lang: "en",
@@ -121,9 +133,10 @@ window.addEventListener("DOMContentLoaded", async () => {
             use_proxy: useProxy.checked,
             proxy_url: proxyHost.value,
             use_lively_voice: livelyVoice.checked,
-            sponsorblock_enabled: currentSettings.sponsorblock_enabled ?? true,
+            sponsorblock_enabled: current?.sponsorblock_enabled ?? true,
             ui_language: uiLanguage.value,
             theme: themeSelect.value,
+            yandex_token: current?.yandex_token,
         };
         try {
             await invoke("save_settings", { newSettings });
@@ -150,12 +163,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     // Language selector — hot-reload
     uiLanguage.addEventListener("change", () => {
         setLocale(uiLanguage.value as Locale);
-        // Re-apply dynamic texts
-        if (authStatus.style.color === "rgb(76, 175, 80)") {
-            authStatus.innerText = t('auth.authorized');
-        } else {
-            authStatus.innerText = t('auth.not_authorized');
-        }
+        updateAuthStatus();
         saveSettings();
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,11 +115,28 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
 
     // Yandex OAuth
-    btnLogin.addEventListener("click", (e) => {
+    const YANDEX_OAUTH_URL = "https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d";
+    const isMobile = /android|iphone|ipad/i.test(navigator.userAgent);
+
+    btnLogin.addEventListener("click", async (e) => {
         e.preventDefault();
         authStatus.innerText = t('auth.redirecting');
         authStatus.style.color = "#FFC131";
-        window.location.href = "https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d";
+
+        if (isMobile) {
+            // On mobile, open OAuth in system browser to avoid webview issues
+            // User will need to copy the token manually or use deep link
+            try {
+                const { openUrl } = await import("@tauri-apps/plugin-opener");
+                await openUrl(YANDEX_OAUTH_URL);
+            } catch (_) {
+                // Fallback: navigate in webview
+                window.location.href = YANDEX_OAUTH_URL;
+            }
+        } else {
+            // On desktop, navigate in webview (injector catches the redirect)
+            window.location.href = YANDEX_OAUTH_URL;
+        }
     });
 
     // Save settings helper — loads current settings first to preserve fields not in UI

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { info, warn, error, debug } from "@tauri-apps/plugin-log";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { Icons } from "./icons";
 import { t, setLocale, type Locale } from "./i18n";
 
@@ -114,28 +115,84 @@ window.addEventListener("DOMContentLoaded", async () => {
         console.error("Failed to load settings:", e);
     }
 
-    // Yandex OAuth
-    const YANDEX_OAUTH_URL = "https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d";
-    const isMobile = /android|iphone|ipad/i.test(navigator.userAgent);
+    // Device Code Flow elements
+    const deviceCodeFlow = document.querySelector("#device-code-flow") as HTMLElement;
+    const deviceUserCode = document.querySelector("#device-user-code") as HTMLElement;
+    const btnOpenDevicePage = document.querySelector("#btn-open-device-page") as HTMLButtonElement;
+    const deviceStatus = document.querySelector("#device-status") as HTMLElement;
+    let devicePollTimer: ReturnType<typeof setInterval> | null = null;
 
+    // Yandex OAuth via Device Code Flow (avoids WebView issues on Android)
     btnLogin.addEventListener("click", async (e) => {
         e.preventDefault();
-        authStatus.innerText = t('auth.redirecting');
+        if (devicePollTimer) return; // already in progress
+
+        authStatus.innerText = t('auth.requesting_code');
         authStatus.style.color = "#FFC131";
 
-        if (isMobile) {
-            // On mobile, open OAuth in system browser to avoid webview issues
-            // User will need to copy the token manually or use deep link
-            try {
-                const { openUrl } = await import("@tauri-apps/plugin-opener");
-                await openUrl(YANDEX_OAUTH_URL);
-            } catch (_) {
-                // Fallback: navigate in webview
-                window.location.href = YANDEX_OAUTH_URL;
-            }
-        } else {
-            // On desktop, navigate in webview (injector catches the redirect)
-            window.location.href = YANDEX_OAUTH_URL;
+        try {
+            const codeResp = await invoke("request_device_code") as {
+                device_code: string;
+                user_code: string;
+                verification_url: string;
+                interval: number;
+                expires_in: number;
+            };
+
+            // Show device code UI
+            deviceCodeFlow.style.display = "block";
+            deviceUserCode.textContent = codeResp.user_code;
+            deviceStatus.innerText = t('auth.waiting_for_auth');
+            deviceStatus.style.color = "#FFC131";
+            btnLogin.disabled = true;
+
+            // Open verification URL in system browser
+            btnOpenDevicePage.onclick = () => {
+                openUrl(codeResp.verification_url);
+            };
+
+            // Poll for token
+            const interval = Math.max(codeResp.interval || 5, 5) * 1000;
+            const expiresAt = Date.now() + codeResp.expires_in * 1000;
+
+            devicePollTimer = setInterval(async () => {
+                if (Date.now() > expiresAt) {
+                    clearInterval(devicePollTimer!);
+                    devicePollTimer = null;
+                    deviceCodeFlow.style.display = "none";
+                    btnLogin.disabled = false;
+                    authStatus.innerText = t('auth.code_expired');
+                    authStatus.style.color = "#ff5e5e";
+                    return;
+                }
+
+                try {
+                    const tokenResp = await invoke("poll_device_token", {
+                        deviceCode: codeResp.device_code
+                    }) as { access_token?: string; error?: string };
+
+                    if (tokenResp.access_token) {
+                        clearInterval(devicePollTimer!);
+                        devicePollTimer = null;
+
+                        // Save token
+                        await invoke("save_yandex_token", { token: tokenResp.access_token });
+                        isAuthorized = true;
+                        updateAuthStatus();
+                        deviceCodeFlow.style.display = "none";
+                        btnLogin.disabled = false;
+                        console.log("Device code auth successful");
+                    }
+                    // If error is "authorization_pending", just keep polling
+                } catch (err) {
+                    console.error("Poll error:", err);
+                }
+            }, interval);
+
+        } catch (err) {
+            console.error("Failed to request device code:", err);
+            authStatus.innerText = t('auth.code_request_failed');
+            authStatus.style.color = "#ff5e5e";
         }
     });
 
@@ -263,19 +320,6 @@ window.addEventListener("DOMContentLoaded", async () => {
         const iconName = el.getAttribute('data-icon');
         if (iconName && Icons[iconName]) {
             el.innerHTML = Icons[iconName];
-        }
-    });
-
-    // Handle bfcache restore (e.g. after OAuth redirect via history.back)
-    // DOMContentLoaded does NOT fire when page is restored from bfcache
-    window.addEventListener("pageshow", async (event) => {
-        if (event.persisted) {
-            console.log("Page restored from bfcache, refreshing auth status");
-            try {
-                const settings: AppSettings = await invoke("get_settings");
-                isAuthorized = !!settings.yandex_token;
-                updateAuthStatus();
-            } catch (_) {}
         }
     });
 


### PR DESCRIPTION
Replace WebView-based OAuth redirect with Device Code Flow to fix
white screen on Android (Yandex blocks embedded WebView).
User now sees a code, opens system browser to authorize, and the app
polls for the token in background.

- Add request_device_code and poll_device_token IPC commands
- Add DeviceCodeResponse/DeviceTokenResponse structs
- Move client_id/client_secret to build-time env vars (.env)
- Remove OAuth token interception from injector.ts
- Remove User-Agent spoofing (no longer needed)
- Add device code UI elements to index.html
- Add i18n keys for device code flow (en/ru)