### PR TITLE
Improve logging, retry logic, status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ By leveraging the power of Rust on the backend, CrabVoice successfully bypasses 
 - **SPA & CSP Resistance:** Survives aggressive Single Page Application navigation and bypasses strict YouTube/VK CSP policies using isolated `Shadow DOM` and `TrustedHTML`.
 - **Auto-Sync:** Native video event hooks automatically sync playback, pausing, and scrubbing between the original video and the translated audio track.
 
+## 🌐 Supported Platforms
+
+CrabVoice uses [vot.js](https://github.com/FOSWLY/vot.js) for video detection across **55+ platforms**. Translation quality and availability depends on the Yandex API's ability to process each platform.
+
+Full list of potentially supported sites: [voice-over-translation wiki](https://github.com/ilyhalight/voice-over-translation/wiki/%5BEN%5D-Supported-sites).
+
+### Known Limitations
+- **TikTok:** Yandex API requires direct video file URLs (`translationHelp`) for non-YouTube platforms. Currently under investigation (#11).
+- **Long videos (4h+):** Yandex API does not support videos longer than 4 hours.
+- **Some platforms** may require proxy for API access depending on your region.
+
 ## 🙏 Acknowledgements
 A huge thank you to the [vot.js](https://github.com/FOSWLY/vot.js) project! Their incredible work on video data extraction, player detection, and API reverse-engineering made the frontend integration of CrabVoice incredibly robust.
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 
         <div class="app-footer">
             <p><span data-i18n="app.crafted_by">Crafted with 🦀 by</span> <a href="https://github.com/ZenonEl" target="_blank">ZenonEl</a></p>
-            <p class="version-info" data-i18n="app.version">CrabVoice v0.7.0 Public Beta</p>
+            <p class="version-info" data-i18n="app.version">CrabVoice v0.8.0 Public Beta</p>
             <p style="font-size:10px;color:#555;margin-top:4px;">(Using <a href="https://sponsor.ajay.app/" style="color:#777;">SponsorBlock</a> data under CC BY-NC-SA 4.0)</p>
 
             <!-- Socials -->

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "CrabVoice",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost",
-    "build": "tsc && vite build",
+    "build:injector": "pnpm dlx esbuild src/injector.ts --bundle --outfile=src-tauri/injector.js --platform=browser \"--external:node:*\"",
+    "build": "pnpm build:injector && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri"
   },
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "esbuild": "^0.27.4",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
@@ -48,8 +51,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -60,8 +75,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -72,8 +99,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -84,8 +123,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -96,8 +147,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -108,8 +171,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -120,8 +195,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -132,8 +219,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -144,8 +243,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -156,8 +267,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -168,8 +291,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -180,8 +315,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -192,8 +339,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -447,6 +606,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -542,79 +706,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -795,6 +1037,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "CrabVoice"
-version = "0.7.0"
+version = "0.8.0"
 description = "Cross-platform real-time voice-over translation app for video platforms. Features native audio sync, vot.js integration, and mobile support"
 authors = ["Zenonel"]
 edition = "2021"

--- a/src-tauri/injector.js
+++ b/src-tauri/injector.js
@@ -3585,7 +3585,7 @@
   var en_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "Real-time Native Video Translation",
-    "app.version": "CrabVoice v0.7.0 Public Beta",
+    "app.version": "CrabVoice v0.8.0 Public Beta",
     "app.crafted_by": "Crafted with \u{1F980} by",
     "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",
     "url.open": "Open Video",
@@ -3645,6 +3645,15 @@
     "status.skipped": "Skipped {category} \u23E9",
     "status.login_success": "Login successful!",
     "status.returning": "Returning to CrabVoice...",
+    "status.retrying": "Retrying... (attempt {attempt}/3) \u23F3",
+    "indicator.proxy.ok": "Proxy connected",
+    "indicator.proxy.off": "Proxy not configured",
+    "indicator.proxy.error": "Proxy connection failed",
+    "indicator.auth.ok": "Yandex authorized",
+    "indicator.auth.off": "Yandex not authorized",
+    "indicator.sb.ok": "SponsorBlock active",
+    "indicator.sb.off": "SponsorBlock disabled",
+    "indicator.sb.error": "SponsorBlock failed to load",
     "error.network": "Connection failed \u2014 check your network",
     "error.api": "Translation service error",
     "error.parse": "Unexpected response from server",
@@ -3659,7 +3668,7 @@
   var ru_default = {
     "app.title": "CrabVoice",
     "app.subtitle": "\u041D\u0430\u0442\u0438\u0432\u043D\u044B\u0439 \u0433\u043E\u043B\u043E\u0441\u043E\u0432\u043E\u0439 \u043F\u0435\u0440\u0435\u0432\u043E\u0434 \u0432\u0438\u0434\u0435\u043E",
-    "app.version": "CrabVoice v0.7.0 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
+    "app.version": "CrabVoice v0.8.0 \u041F\u0443\u0431\u043B\u0438\u0447\u043D\u0430\u044F \u0431\u0435\u0442\u0430",
     "app.crafted_by": "\u0421\u0434\u0435\u043B\u0430\u043D\u043E \u0441 \u{1F980} \u043E\u0442",
     "url.placeholder": "\u0412\u0441\u0442\u0430\u0432\u044C\u0442\u0435 \u0441\u0441\u044B\u043B\u043A\u0443 \u043D\u0430 \u0432\u0438\u0434\u0435\u043E (YouTube, VK, Vimeo)...",
     "url.open": "\u041E\u0442\u043A\u0440\u044B\u0442\u044C \u0432\u0438\u0434\u0435\u043E",
@@ -3719,6 +3728,15 @@
     "status.skipped": "\u041F\u0440\u043E\u043F\u0443\u0449\u0435\u043D\u043E: {category} \u23E9",
     "status.login_success": "\u0412\u0445\u043E\u0434 \u0432\u044B\u043F\u043E\u043B\u043D\u0435\u043D!",
     "status.returning": "\u0412\u043E\u0437\u0432\u0440\u0430\u0442 \u0432 CrabVoice...",
+    "status.retrying": "\u041F\u043E\u0432\u0442\u043E\u0440... (\u043F\u043E\u043F\u044B\u0442\u043A\u0430 {attempt}/3) \u23F3",
+    "indicator.proxy.ok": "\u041F\u0440\u043E\u043A\u0441\u0438 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0451\u043D",
+    "indicator.proxy.off": "\u041F\u0440\u043E\u043A\u0441\u0438 \u043D\u0435 \u043D\u0430\u0441\u0442\u0440\u043E\u0435\u043D",
+    "indicator.proxy.error": "\u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u044F \u043F\u0440\u043E\u043A\u0441\u0438",
+    "indicator.auth.ok": "\u042F\u043D\u0434\u0435\u043A\u0441 \u0430\u0432\u0442\u043E\u0440\u0438\u0437\u043E\u0432\u0430\u043D",
+    "indicator.auth.off": "\u042F\u043D\u0434\u0435\u043A\u0441 \u043D\u0435 \u0430\u0432\u0442\u043E\u0440\u0438\u0437\u043E\u0432\u0430\u043D",
+    "indicator.sb.ok": "SponsorBlock \u0430\u043A\u0442\u0438\u0432\u0435\u043D",
+    "indicator.sb.off": "SponsorBlock \u043E\u0442\u043A\u043B\u044E\u0447\u0451\u043D",
+    "indicator.sb.error": "\u041E\u0448\u0438\u0431\u043A\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043A\u0438 SponsorBlock",
     "error.network": "\u041E\u0448\u0438\u0431\u043A\u0430 \u043F\u043E\u0434\u043A\u043B\u044E\u0447\u0435\u043D\u0438\u044F \u2014 \u043F\u0440\u043E\u0432\u0435\u0440\u044C\u0442\u0435 \u0441\u0435\u0442\u044C",
     "error.api": "\u041E\u0448\u0438\u0431\u043A\u0430 \u0441\u0435\u0440\u0432\u0438\u0441\u0430 \u043F\u0435\u0440\u0435\u0432\u043E\u0434\u0430",
     "error.parse": "\u041D\u0435\u043E\u0436\u0438\u0434\u0430\u043D\u043D\u044B\u0439 \u043E\u0442\u0432\u0435\u0442 \u043E\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430",
@@ -3917,6 +3935,21 @@
                 }
                 .cv-pro-crown svg { width: 14px; height: 14px; stroke: #FFD700; filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.6)); }
 
+                .cv-indicators {
+                    display: flex; justify-content: center; gap: 12px;
+                    margin-bottom: 10px; font-size: 10px; color: #aaa;
+                }
+                .cv-indicator {
+                    display: inline-flex; align-items: center; gap: 4px;
+                }
+                .cv-dot {
+                    display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+                    transition: background-color 0.3s;
+                }
+                .cv-dot--ok { background-color: #4CAF50; }
+                .cv-dot--off { background-color: #666; }
+                .cv-dot--error { background-color: #ff5e5e; }
+
                 .cv-sb-btn {
                     display: flex; align-items: center; justify-content: center; gap: 4px;
                     background: #333 !important; color: #fff !important; border: 1px solid #555 !important;
@@ -3940,8 +3973,13 @@
                         <button class="cv-btn-collapse" id="cv-btn-collapse" title="Minimize">${Icons.collapse}</button>
                     </div>
                     <div class="cv-content">
-                        <div style="font-size:12px; margin-bottom: 12px; text-align:center;">
+                        <div style="font-size:12px; margin-bottom: 6px; text-align:center;">
                             <span id="cv-status" style="color:#FFC131">${t("panel.searching")}</span>
+                        </div>
+                        <div class="cv-indicators" id="cv-indicators">
+                            <span class="cv-indicator" id="cv-ind-proxy" title="${t("indicator.proxy.off")}"><span class="cv-dot cv-dot--off"></span> Proxy</span>
+                            <span class="cv-indicator" id="cv-ind-auth" title="${t("indicator.auth.off")}"><span class="cv-dot cv-dot--off"></span> Auth</span>
+                            <span class="cv-indicator" id="cv-ind-sponsorblock" style="display:${this.tier !== "free" ? "inline-flex" : "none"}" title="${t("indicator.sb.off")}"><span class="cv-dot cv-dot--off"></span> SB</span>
                         </div>
 
                         <div class="cv-row">
@@ -4126,6 +4164,16 @@
       this.sponsorBlockEnabled = enabled;
       this.updateSponsorBlockButton();
     }
+    updateIndicator(id, status) {
+      const el = this.shadow.getElementById(`cv-ind-${id}`);
+      if (!el) return;
+      const dot = el.querySelector(".cv-dot");
+      if (dot) {
+        dot.className = `cv-dot cv-dot--${status}`;
+      }
+      const tooltipKey = id === "sponsorblock" ? `indicator.sb.${status}` : `indicator.${id}.${status}`;
+      el.title = t(tooltipKey);
+    }
   };
 
   // src/injector.ts
@@ -4215,6 +4263,7 @@ ${a.stack}`;
       isTranslating = true;
       currentVideoUrl = window.location.href;
       let attempts = 0;
+      let apiErrorRetries = 0;
       if (!appSettings && window.__TAURI__) {
         try {
           appSettings = await window.__TAURI__.core.invoke("get_settings");
@@ -4226,6 +4275,18 @@ ${a.stack}`;
           if (panelInstance) {
             panelInstance.setVideoVolumeSlider(userVideoVolume);
             panelInstance.setSponsorBlockState(sponsorBlockEnabled);
+            panelInstance.updateIndicator("sponsorblock", sponsorBlockEnabled ? "ok" : "off");
+            panelInstance.updateIndicator("auth", appSettings.yandex_token ? "ok" : "off");
+            if (appSettings.use_proxy && appSettings.proxy_url) {
+              panelInstance.updateIndicator("proxy", "ok");
+              try {
+                await window.__TAURI__.core.invoke("ping_proxy", { proxyUrl: appSettings.proxy_url });
+              } catch {
+                panelInstance.updateIndicator("proxy", "error");
+              }
+            } else {
+              panelInstance.updateIndicator("proxy", "off");
+            }
           }
         } catch (e) {
           console.error("CrabVoice: Failed to fetch settings", e);
@@ -4243,6 +4304,7 @@ ${a.stack}`;
         updateStatus(t("status.extracting"), "#24c8db");
         const videoData = await getVideoData(service);
         const duration = videoData?.duration || v.duration || 344;
+        appLog(`Video data: service=${JSON.stringify(service.host)}, duration=${duration}, videoId=${videoData?.videoId ?? "unknown"}`);
         if (appTier !== "free" && sponsorBlockEnabled && window.location.hostname.includes("youtube.com")) {
           const urlObj = new URL(window.location.href);
           const videoId = urlObj.searchParams.get("v");
@@ -4252,12 +4314,15 @@ ${a.stack}`;
               if (sponsorSegments.length > 0) {
                 appLog(`SponsorBlock: Loaded ${sponsorSegments.length} segments`);
               }
+              if (panelInstance) panelInstance.updateIndicator("sponsorblock", "ok");
             } catch (e) {
+              if (panelInstance) panelInstance.updateIndicator("sponsorblock", "error");
             }
           }
         }
         const pollTranslation = async () => {
           if (window.location.href !== currentVideoUrl) {
+            appLog("URL changed, stopping poll");
             isTranslating = false;
             return;
           }
@@ -4269,11 +4334,12 @@ ${a.stack}`;
           try {
             const invoke = window.__TAURI__ ? window.__TAURI__.core.invoke : null;
             if (!invoke) return;
-            appLog("Sent translation request to Rust backend");
+            appLog(`Poll attempt=${attempts}, firstRequest=${attempts === 0}`);
             const res = await Promise.race([
               invoke("translate", { url: window.location.href, duration, firstRequest: attempts === 0 }),
               new Promise((_, reject) => setTimeout(() => reject(new Error("Network error")), 35e3))
             ]);
+            appLog(`Response: status=${res.status}, remaining_time=${res.remaining_time ?? "none"}, hasUrl=${!!res.url}`);
             if (res.status === 1 && res.url) {
               appLog("Translation successful! Playing native audio...");
               updateStatus(t("status.linked"), "#4CAF50");
@@ -4312,10 +4378,19 @@ ${a.stack}`;
             }
           } catch (e) {
             const errStr = e?.toString() ?? "";
-            appLog(`Backend error: ${errStr}`);
+            appLog(`Backend error (attempt=${attempts}): ${errStr}`);
+            const isApiError = errStr.includes("API error");
+            if (isApiError && apiErrorRetries < 3) {
+              apiErrorRetries++;
+              appLog(`API error retry ${apiErrorRetries}/3 \u2014 restarting session in 10s`);
+              updateStatus(t("status.retrying", { attempt: apiErrorRetries }), "#FFC131");
+              attempts = 0;
+              setTimeout(pollTranslation, 1e4);
+              return;
+            }
             let userMsg = t("error.unknown");
             if (errStr.startsWith("Network error")) userMsg = t("error.network");
-            else if (errStr.startsWith("API error")) userMsg = t("error.api");
+            else if (isApiError) userMsg = t("error.api");
             else if (errStr.startsWith("Parse error")) userMsg = t("error.parse");
             else if (errStr.startsWith("Config error")) userMsg = t("error.config");
             updateStatus(userMsg + " \u26A0\uFE0F", "#ff5e5e");
@@ -4405,6 +4480,7 @@ ${a.stack}`;
           },
           onSponsorBlockToggle: (enabled) => {
             sponsorBlockEnabled = enabled;
+            if (panelInstance) panelInstance.updateIndicator("sponsorblock", enabled ? "ok" : "off");
             appLog(`SponsorBlock toggled: ${enabled}`);
             if (window.__TAURI__ && appSettings) {
               appSettings.sponsorblock_enabled = enabled;

--- a/src-tauri/src/yandex_api.rs
+++ b/src-tauri/src/yandex_api.rs
@@ -2,7 +2,7 @@ use crate::domain::{AppSettings, TranslationProvider, TranslationResult};
 use crate::error::AppError;
 use async_trait::async_trait;
 use hmac::{Hmac, Mac};
-use log::{debug, warn};
+use log::{debug, info, warn};
 use prost::Message;
 use reqwest::{header, Client};
 use sha2::Sha256;
@@ -56,9 +56,9 @@ impl TranslationProvider for YandexClient {
         let signature_hex = hex::encode(mac.finalize().into_bytes());
         let uuid_str = Uuid::new_v4().to_string();
 
-        debug!(
-            "Yandex API: {} -> {}, duration={:.0}s, lively={}",
-            settings.default_source_lang, settings.default_target_lang, duration, settings.use_lively_voice
+        info!(
+            "Yandex API request: {} -> {}, duration={:.0}s, lively={}, first_request={}",
+            settings.default_source_lang, settings.default_target_lang, duration, settings.use_lively_voice, first_request
         );
 
         let mut headers = header::HeaderMap::new();
@@ -68,7 +68,7 @@ impl TranslationProvider for YandexClient {
 
         let mut client_builder = Client::builder()
             .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(30));
+            .timeout(std::time::Duration::from_secs(60));
 
         if settings.use_proxy && !settings.proxy_url.is_empty() {
             match reqwest::Proxy::all(&settings.proxy_url) {
@@ -114,13 +114,13 @@ impl TranslationProvider for YandexClient {
             let status = response.status();
             let err_text = response.text().await.unwrap_or_default();
             warn!("Yandex API HTTP {}: {}", status, err_text);
-            return Err(AppError::Api(format!("Yandex HTTP {}", status)));
+            return Err(AppError::Api(format!("Yandex HTTP {}: {}", status, err_text)));
         }
 
         let response_bytes = response.bytes().await?;
         let yandex_response = pb::VideoTranslationResponse::decode(response_bytes)?;
 
-        debug!(
+        info!(
             "Yandex response: status={}, url={}, remaining_time={:?}",
             yandex_response.status,
             yandex_response.url.as_deref().unwrap_or("none"),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CrabVoice",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.zenonel.crabvoice",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -46,6 +46,9 @@ interface AppSettings {
     default_target_lang: string;
     sponsorblock_enabled: boolean;
     ui_language: string;
+    use_proxy: boolean;
+    proxy_url: string;
+    yandex_token: string | null;
 }
 
 if (!window._cvInitialized) {
@@ -141,6 +144,7 @@ if (!window._cvInitialized) {
         isTranslating = true;
         currentVideoUrl = window.location.href;
         let attempts = 0;
+        let apiErrorRetries = 0;
 
         // Загружаем настройки из Rust, если еще не загрузили
         if (!appSettings && window.__TAURI__) {
@@ -155,6 +159,20 @@ if (!window._cvInitialized) {
                 if (panelInstance) {
                     panelInstance.setVideoVolumeSlider(userVideoVolume);
                     panelInstance.setSponsorBlockState(sponsorBlockEnabled);
+
+                    // Update status indicators
+                    panelInstance.updateIndicator('sponsorblock', sponsorBlockEnabled ? 'ok' : 'off');
+                    panelInstance.updateIndicator('auth', appSettings!.yandex_token ? 'ok' : 'off');
+                    if (appSettings!.use_proxy && appSettings!.proxy_url) {
+                        panelInstance.updateIndicator('proxy', 'ok');
+                        try {
+                            await window.__TAURI__!.core.invoke("ping_proxy", { proxyUrl: appSettings!.proxy_url });
+                        } catch {
+                            panelInstance.updateIndicator('proxy', 'error');
+                        }
+                    } else {
+                        panelInstance.updateIndicator('proxy', 'off');
+                    }
                 }
             } catch (e) { console.error("CrabVoice: Failed to fetch settings", e); }
         }
@@ -177,6 +195,7 @@ if (!window._cvInitialized) {
             const videoData = await getVideoData(service);
 
             const duration = videoData?.duration || v.duration || 344.0;
+            appLog(`Video data: service=${JSON.stringify(service.host)}, duration=${duration}, videoId=${videoData?.videoId ?? 'unknown'}`);
 
             // Load SponsorBlock segments (subscribers+ tier, YouTube only)
             if (appTier !== 'free' && sponsorBlockEnabled && window.location.hostname.includes("youtube.com")) {
@@ -188,14 +207,16 @@ if (!window._cvInitialized) {
                         if (sponsorSegments.length > 0) {
                             appLog(`SponsorBlock: Loaded ${sponsorSegments.length} segments`);
                         }
+                        if (panelInstance) panelInstance.updateIndicator('sponsorblock', 'ok');
                     } catch (e) {
-                        // Ошибка или бесплатная версия — просто игнорируем
+                        if (panelInstance) panelInstance.updateIndicator('sponsorblock', 'error');
                     }
                 }
             }
 
             const pollTranslation = async () => {
                 if (window.location.href !== currentVideoUrl) {
+                    appLog("URL changed, stopping poll");
                     isTranslating = false;
                     return;
                 }
@@ -211,12 +232,14 @@ if (!window._cvInitialized) {
                     const invoke = window.__TAURI__ ? window.__TAURI__.core.invoke : null;
                     if (!invoke) return;
 
-                    appLog("Sent translation request to Rust backend");
+                    appLog(`Poll attempt=${attempts}, firstRequest=${attempts === 0}`);
                     const res = await Promise.race([
                         invoke("translate", { url: window.location.href, duration, firstRequest: attempts === 0 }),
                         new Promise((_, reject) => setTimeout(() => reject(new Error("Network error")), 35000))
                     ]) as any;
                     
+                    appLog(`Response: status=${res.status}, remaining_time=${res.remaining_time ?? 'none'}, hasUrl=${!!res.url}`);
+
                     if (res.status === 1 && res.url) {
                         appLog("Translation successful! Playing native audio...");
                         updateStatus(t('status.linked'), "#4CAF50");
@@ -260,11 +283,21 @@ if (!window._cvInitialized) {
                     }
                 } catch (e: any) {
                     const errStr = e?.toString() ?? '';
-                    appLog(`Backend error: ${errStr}`);
-                    // Map structured error categories to user-friendly i18n messages
+                    appLog(`Backend error (attempt=${attempts}): ${errStr}`);
+
+                    const isApiError = errStr.includes('API error');
+                    if (isApiError && apiErrorRetries < 3) {
+                        apiErrorRetries++;
+                        appLog(`API error retry ${apiErrorRetries}/3 — restarting session in 10s`);
+                        updateStatus(t('status.retrying', { attempt: apiErrorRetries }), "#FFC131");
+                        attempts = 0;
+                        setTimeout(pollTranslation, 10000);
+                        return;
+                    }
+
                     let userMsg = t('error.unknown');
                     if (errStr.startsWith('Network error')) userMsg = t('error.network');
-                    else if (errStr.startsWith('API error')) userMsg = t('error.api');
+                    else if (isApiError) userMsg = t('error.api');
                     else if (errStr.startsWith('Parse error')) userMsg = t('error.parse');
                     else if (errStr.startsWith('Config error')) userMsg = t('error.config');
                     updateStatus(userMsg + " ⚠️", "#ff5e5e");
@@ -356,6 +389,7 @@ if (!window._cvInitialized) {
                 },
                 onSponsorBlockToggle: (enabled: boolean) => {
                     sponsorBlockEnabled = enabled;
+                    if (panelInstance) panelInstance.updateIndicator('sponsorblock', enabled ? 'ok' : 'off');
                     appLog(`SponsorBlock toggled: ${enabled}`);
                     // Persist setting
                     if (window.__TAURI__ && appSettings) {

--- a/src/injectorPanel.ts
+++ b/src/injectorPanel.ts
@@ -2,6 +2,8 @@ import { Icons } from "./icons";
 import { t } from "./i18n";
 
 export type AppTier = 'free' | 'subscribers' | 'premium';
+export type IndicatorStatus = 'ok' | 'off' | 'error';
+export type IndicatorId = 'proxy' | 'auth' | 'sponsorblock';
 
 export interface PanelCallbacks {
     onClose: () => void;
@@ -179,6 +181,21 @@ export class CrabPanel {
                 }
                 .cv-pro-crown svg { width: 14px; height: 14px; stroke: #FFD700; filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.6)); }
 
+                .cv-indicators {
+                    display: flex; justify-content: center; gap: 12px;
+                    margin-bottom: 10px; font-size: 10px; color: #aaa;
+                }
+                .cv-indicator {
+                    display: inline-flex; align-items: center; gap: 4px;
+                }
+                .cv-dot {
+                    display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+                    transition: background-color 0.3s;
+                }
+                .cv-dot--ok { background-color: #4CAF50; }
+                .cv-dot--off { background-color: #666; }
+                .cv-dot--error { background-color: #ff5e5e; }
+
                 .cv-sb-btn {
                     display: flex; align-items: center; justify-content: center; gap: 4px;
                     background: #333 !important; color: #fff !important; border: 1px solid #555 !important;
@@ -202,8 +219,13 @@ export class CrabPanel {
                         <button class="cv-btn-collapse" id="cv-btn-collapse" title="Minimize">${Icons.collapse}</button>
                     </div>
                     <div class="cv-content">
-                        <div style="font-size:12px; margin-bottom: 12px; text-align:center;">
+                        <div style="font-size:12px; margin-bottom: 6px; text-align:center;">
                             <span id="cv-status" style="color:#FFC131">${t('panel.searching')}</span>
+                        </div>
+                        <div class="cv-indicators" id="cv-indicators">
+                            <span class="cv-indicator" id="cv-ind-proxy" title="${t('indicator.proxy.off')}"><span class="cv-dot cv-dot--off"></span> Proxy</span>
+                            <span class="cv-indicator" id="cv-ind-auth" title="${t('indicator.auth.off')}"><span class="cv-dot cv-dot--off"></span> Auth</span>
+                            <span class="cv-indicator" id="cv-ind-sponsorblock" style="display:${this.tier !== 'free' ? 'inline-flex' : 'none'}" title="${t('indicator.sb.off')}"><span class="cv-dot cv-dot--off"></span> SB</span>
                         </div>
 
                         <div class="cv-row">
@@ -432,5 +454,16 @@ export class CrabPanel {
     public setSponsorBlockState(enabled: boolean) {
         this.sponsorBlockEnabled = enabled;
         this.updateSponsorBlockButton();
+    }
+
+    public updateIndicator(id: IndicatorId, status: IndicatorStatus) {
+        const el = this.shadow.getElementById(`cv-ind-${id}`);
+        if (!el) return;
+        const dot = el.querySelector('.cv-dot');
+        if (dot) {
+            dot.className = `cv-dot cv-dot--${status}`;
+        }
+        const tooltipKey = id === 'sponsorblock' ? `indicator.sb.${status}` : `indicator.${id}.${status}`;
+        el.title = t(tooltipKey);
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Real-time Native Video Translation",
-  "app.version": "CrabVoice v0.7.0 Public Beta",
+  "app.version": "CrabVoice v0.8.0 Public Beta",
   "app.crafted_by": "Crafted with 🦀 by",
 
   "url.placeholder": "Paste video URL (YouTube, VK, Vimeo)...",
@@ -68,6 +68,17 @@
   "status.skipped": "Skipped {category} ⏩",
   "status.login_success": "Login successful!",
   "status.returning": "Returning to CrabVoice...",
+
+  "status.retrying": "Retrying... (attempt {attempt}/3) ⏳",
+
+  "indicator.proxy.ok": "Proxy connected",
+  "indicator.proxy.off": "Proxy not configured",
+  "indicator.proxy.error": "Proxy connection failed",
+  "indicator.auth.ok": "Yandex authorized",
+  "indicator.auth.off": "Yandex not authorized",
+  "indicator.sb.ok": "SponsorBlock active",
+  "indicator.sb.off": "SponsorBlock disabled",
+  "indicator.sb.error": "SponsorBlock failed to load",
 
   "error.network": "Connection failed — check your network",
   "error.api": "Translation service error",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,7 +1,7 @@
 {
   "app.title": "CrabVoice",
   "app.subtitle": "Нативный голосовой перевод видео",
-  "app.version": "CrabVoice v0.7.0 Публичная бета",
+  "app.version": "CrabVoice v0.8.0 Публичная бета",
   "app.crafted_by": "Сделано с 🦀 от",
 
   "url.placeholder": "Вставьте ссылку на видео (YouTube, VK, Vimeo)...",
@@ -68,6 +68,17 @@
   "status.skipped": "Пропущено: {category} ⏩",
   "status.login_success": "Вход выполнен!",
   "status.returning": "Возврат в CrabVoice...",
+
+  "status.retrying": "Повтор... (попытка {attempt}/3) ⏳",
+
+  "indicator.proxy.ok": "Прокси подключён",
+  "indicator.proxy.off": "Прокси не настроен",
+  "indicator.proxy.error": "Ошибка подключения прокси",
+  "indicator.auth.ok": "Яндекс авторизован",
+  "indicator.auth.off": "Яндекс не авторизован",
+  "indicator.sb.ok": "SponsorBlock активен",
+  "indicator.sb.off": "SponsorBlock отключён",
+  "indicator.sb.error": "Ошибка загрузки SponsorBlock",
 
   "error.network": "Ошибка подключения — проверьте сеть",
   "error.api": "Ошибка сервиса перевода",


### PR DESCRIPTION
- Backend: debug→info for Yandex API request/response logs, include response body in errors, increase timeout to 60s
- Frontend: detailed pipeline logging (attempt, service, videoId, response status), retry up to 3 times on API errors with session restart
- Panel: add status indicator dots (Proxy/Auth/SB) with ok/off/error states and i18n tooltips
- Build: add build:injector script (esbuild), integrate into build pipeline
- README: add supported platforms section with vot.js wiki link and known limitations
- i18n: add retrying status and indicator tooltip keys (en/ru)